### PR TITLE
fix: 修复rtt新版本编译无法找到函数“atoi”问题

### DIFF
--- a/icm20608.c
+++ b/icm20608.c
@@ -14,6 +14,7 @@
 #include <finsh.h>
 
 #include <string.h>
+#include <stdlib.h>
 #include "icm20608.h"
 
 #ifdef PKG_USING_ICM20608


### PR DESCRIPTION
修复rtthread5.2.0版本下，使能星火一号板上陀螺仪测试，icm20608.c文件在keil5环境中编译报错
![image](https://github.com/user-attachments/assets/0a9248f9-267a-416a-a7e6-3e851d8cd848)
